### PR TITLE
Sending logs to Docker output

### DIFF
--- a/app/config/packages/dev/monolog.yaml
+++ b/app/config/packages/dev/monolog.yaml
@@ -2,7 +2,9 @@ monolog:
     handlers:
         main:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            # Output logs to Docker stderr by default
+            path: "php://stderr"
+            #path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
             channels: ["!event"]
         # uncomment to get logging in your browser

--- a/app/config/packages/prod/monolog.yaml
+++ b/app/config/packages/prod/monolog.yaml
@@ -9,7 +9,9 @@ monolog:
                 - ^/
         nested:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            # Output logs to Docker stderr by default
+            path: "php://stderr"
+            #path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
         console:
             type: console


### PR DESCRIPTION
This PR sends logs directly to stderr (they can therefore be displayed by the Docker container) rather than in [project]/var/log files.