### PR TITLE
Adding logging of stack traces in Symfony logs

### DIFF
--- a/src/api/config/packages/dev/monolog.yaml
+++ b/src/api/config/packages/dev/monolog.yaml
@@ -5,6 +5,7 @@ monolog:
             path: '%env(MONOLOG_LOGGING_PATH)%'
             level: debug
             channels: ["!event"]
+            formatter: formatterWithStackTrace
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:

--- a/src/api/config/packages/prod/monolog.yaml
+++ b/src/api/config/packages/prod/monolog.yaml
@@ -6,6 +6,7 @@ monolog:
             handler: nested
             excluded_http_codes: [404, 405]
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+            formatter: formatterWithStackTrace
         nested:
             type: stream
             path: '%env(MONOLOG_LOGGING_PATH)%'

--- a/src/api/config/packages/test/monolog.yaml
+++ b/src/api/config/packages/test/monolog.yaml
@@ -6,6 +6,7 @@ monolog:
             handler: nested
             excluded_http_codes: [404, 405]
             channels: ["!event"]
+            formatter: formatterWithStackTrace
         nested:
             type: stream
             path: '%env(MONOLOG_LOGGING_PATH)%'

--- a/src/api/config/services.yaml
+++ b/src/api/config/services.yaml
@@ -48,3 +48,9 @@ services:
     App\Infrastructure\EventSubscriber\LocaleSubscriber:
         arguments:
             - '%kernel.default_locale%'
+
+    # A special kind of formatter that logs the stack traces (otherwise, Symfony logs do not contain stack traces (!) )
+    formatterWithStackTrace:
+        class: Monolog\Formatter\LineFormatter
+        calls:
+            - [includeStacktraces]


### PR DESCRIPTION
By default, Symfony does not log stack traces in its logs.

...

Yeah... this is very surprising, but it's true. This commit configures a special Monolog formatter that actually logs stack traces (so we can see where a problem occurs in production logs!)